### PR TITLE
Fix kitspace.yaml

### DIFF
--- a/kitspace.yaml
+++ b/kitspace.yaml
@@ -1,3 +1,3 @@
 bom: BOM/ArduTouch_BOM.csv
-gerbers: Gerbers/output
+gerbers: Gerbers/outputs
 color: blue


### PR DESCRIPTION
That shouldn't have worked the way it was, because that path doesn't exist. But it did, now we are fixing it. 